### PR TITLE
feat(backend): get ETH address of a principal

### DIFF
--- a/src/backend/backend.did
+++ b/src/backend/backend.did
@@ -42,6 +42,7 @@ type SignRequest = record {
 };
 service : (Arg) -> {
   caller_eth_address : () -> (text);
+  eth_address_of : (principal) -> (text);
   get_canister_status : () -> (CanisterStatusResultV2);
   http_request : (HttpRequest) -> (HttpResponse) query;
   personal_sign : (text) -> (text);

--- a/src/backend/src/lib.rs
+++ b/src/backend/src/lib.rs
@@ -125,6 +125,15 @@ async fn caller_eth_address() -> String {
     pubkey_bytes_to_address(&ecdsa_pubkey_of(&ic_cdk::caller()).await)
 }
 
+/// Returns the Ethereum address of the specified .
+#[update]
+async fn eth_address_of(p: Principal) -> String {
+    if p == Principal::anonymous() {
+        ic_cdk::trap("Anonymous principal is not authorized");
+    }
+    pubkey_bytes_to_address(&ecdsa_pubkey_of(&p).await)
+}
+
 #[derive(CandidType, Deserialize)]
 pub struct SignRequest {
     pub chain_id: Nat,

--- a/src/declarations/backend/backend.did.d.ts
+++ b/src/declarations/backend/backend.did.d.ts
@@ -47,6 +47,7 @@ export interface SignRequest {
 }
 export interface _SERVICE {
 	caller_eth_address: ActorMethod<[], string>;
+	eth_address_of: ActorMethod<[Principal], string>;
 	get_canister_status: ActorMethod<[], CanisterStatusResultV2>;
 	http_request: ActorMethod<[HttpRequest], HttpResponse>;
 	personal_sign: ActorMethod<[string], string>;

--- a/src/declarations/backend/backend.factory.did.js
+++ b/src/declarations/backend/backend.factory.did.js
@@ -48,6 +48,7 @@ export const idlFactory = ({ IDL }) => {
 	});
 	return IDL.Service({
 		caller_eth_address: IDL.Func([], [IDL.Text], []),
+		eth_address_of: IDL.Func([IDL.Principal], [IDL.Text], []),
 		get_canister_status: IDL.Func([], [CanisterStatusResultV2], []),
 		http_request: IDL.Func([HttpRequest], [HttpResponse], ['query']),
 		personal_sign: IDL.Func([IDL.Text], [IDL.Text], []),


### PR DESCRIPTION
This change adds a method to compute the ETH address of a given principal, `eth_address_of`.