### PR TITLE
chore(airdrop): Rename fields

### DIFF
--- a/src/airdrop/src/guards.rs
+++ b/src/airdrop/src/guards.rs
@@ -5,7 +5,7 @@ pub fn caller_is_admin() -> Result<(), String> {
     let caller = caller();
 
     read_state(|state| {
-        if state.principals_admin.contains(&caller) {
+        if state.principals_admins.contains(&caller) {
             Ok(())
         } else {
             Err("Caller is not an authorized admin".to_string())

--- a/src/airdrop/src/lib.rs
+++ b/src/airdrop/src/lib.rs
@@ -77,7 +77,7 @@ fn init(arg: Arg) {
                 maximum_depth,
                 numbers_of_children,
                 total_tokens,
-                principals_admin: HashSet::from([caller()]),
+                principals_admins: HashSet::from([caller()]),
                 ..State::default()
             })
         }),
@@ -114,7 +114,7 @@ pub fn add_codes(codes: Vec<String>) -> CustomResult<()> {
 #[update(guard = "caller_is_admin")]
 pub fn add_admin(principal: Principal) -> CustomResult<()> {
     mutate_state(|state| {
-        state.principals_admin.insert(principal);
+        state.principals_admins.insert(principal);
 
         Ok(())
     })
@@ -175,9 +175,6 @@ pub fn generate_code() -> CustomResult<CodeInfo> {
 }
 
 /// Function to be called when the user has a code
-/// The code the user wants to redeem
-/// The ETH address of the user
-/// TODO: to be reviewed
 #[update]
 pub async fn redeem_code(code: Code) -> CustomResult<Info> {
     check_if_killed()?;
@@ -187,7 +184,7 @@ pub async fn redeem_code(code: Code) -> CustomResult<Info> {
 
     mutate_state(|state| {
         // Check if the given principal has redeemed any code yet
-        if state.principals_user_eth.contains_key(&caller_principal) {
+        if state.principals_users.contains_key(&caller_principal) {
             return Err(CanisterError::CannotRegisterMultipleTimes);
         }
 
@@ -213,7 +210,7 @@ pub async fn redeem_code(code: Code) -> CustomResult<Info> {
         } else {
             // TODO in this current configuration managers do not get the airdrop
             // add parent eth address to the list of eth addresses to send tokens to
-            if let Some((_, parent_eth_address)) = state.principals_user_eth.get(&parent_principal)
+            if let Some((_, parent_eth_address)) = state.principals_users.get(&parent_principal)
             {
                 add_user_to_airdrop_reward(
                     state,
@@ -287,7 +284,7 @@ pub fn get_code() -> CustomResult<Info> {
     read_state(|state| {
         // get the code and eth_address associated with the principal
         let (code, eth_address) = state
-            .principals_user_eth
+            .principals_users
             .get(&caller_principal)
             .cloned()
             .ok_or(CanisterError::CodeNotFound)?;

--- a/src/airdrop/src/state.rs
+++ b/src/airdrop/src/state.rs
@@ -5,17 +5,17 @@ use std::collections::{HashMap, HashSet};
 #[derive(Serialize, Deserialize, Clone, CandidType)]
 pub struct State {
     // Admin principals - the principals that can add new principals that can generate codes and get the list of airdrop to do
-    pub principals_admin: HashSet<Principal>,
+    pub principals_admins: HashSet<Principal>,
     /// Manager principals - for principals allowed to generate codes
     pub principals_managers: HashMap<Principal, PrincipalState>,
     // User principals - map Principal to (Code, Eth Address)
-    pub principals_user_eth: HashMap<Principal, (Code, EthereumAddress)>,
+    pub principals_users: HashMap<Principal, (Code, EthereumAddress)>,
     // pre-generated codes
     pub pre_generated_codes: Vec<Code>,
     /// Map a Code to it's parent principal, the depth, whether it has been redeemed
     pub codes: HashMap<Code, CodeState>,
     // id (the index) mapped to the (EthAddress, AirdropAmount)
-    pub airdrop_reward: Vec<EthAddressAmount>,
+    pub airdrop_reward: Vec<EthereumTransaction>,
     // has the canister been killed
     pub killed: bool,
     // total number of tokens
@@ -32,9 +32,9 @@ pub struct State {
 impl Default for State {
     fn default() -> Self {
         State {
-            principals_admin: HashSet::new(),
+            principals_admins: HashSet::new(),
             principals_managers: HashMap::new(),
-            principals_user_eth: HashMap::new(),
+            principals_users: HashMap::new(),
             pre_generated_codes: Vec::new(),
             codes: HashMap::new(),
             airdrop_reward: Vec::new(),
@@ -128,13 +128,13 @@ impl CodeState {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, Default, CandidType)]
-pub struct EthAddressAmount {
+pub struct EthereumTransaction {
     pub eth_address: EthereumAddress,
     pub amount: AirdropAmount,
     pub transferred: bool,
 }
 
-impl EthAddressAmount {
+impl EthereumTransaction {
     pub fn new(eth_address: EthereumAddress, amount: AirdropAmount, transferred: bool) -> Self {
         Self {
             eth_address,

--- a/src/airdrop/src/utils.rs
+++ b/src/airdrop/src/utils.rs
@@ -3,7 +3,7 @@ use ic_cdk::api::call::CallResult;
 use ic_cdk::{call, caller};
 
 use crate::read_state;
-use crate::state::{EthAddressAmount, EthereumAddress, State};
+use crate::state::{EthereumTransaction, EthereumAddress, State};
 use crate::CanisterError::{CanisterKilled, GeneralError, NoMoreCodes, UnknownOisyWalletAddress};
 use crate::{AirdropAmount, Code, CustomResult};
 
@@ -48,7 +48,7 @@ pub fn register_principal_with_eth_address(
     eth_address: EthereumAddress,
 ) {
     state
-        .principals_user_eth
+        .principals_users
         .insert(principal, (code, eth_address));
 }
 
@@ -63,7 +63,7 @@ pub fn add_user_to_airdrop_reward(
 
     state
         .airdrop_reward
-        .push(EthAddressAmount::new(eth_address, amount, false));
+        .push(EthereumTransaction::new(eth_address, amount, false));
 }
 
 // "generate" codes


### PR DESCRIPTION
After multiple rewrites/change directions, some fields' names do not reflect their actual use. 