### PR TITLE
fix(airdrop): Prevent duplicate key creation

### DIFF
--- a/src/airdrop/airdrop.did
+++ b/src/airdrop/airdrop.did
@@ -10,6 +10,7 @@ type CanisterError = variant {
   CodeAlreadyRedeemed;
   TransactionUnkown;
   CodeNotFound;
+  DuplicateKey : text;
   NoCodeForII;
 };
 type CodeInfo = record {

--- a/src/airdrop/src/lib.rs
+++ b/src/airdrop/src/lib.rs
@@ -142,9 +142,7 @@ fn add_codes(codes: Vec<String>) -> CustomResult<()> {
     mutate_state(|state| {
         for code in codes {
             // only add the code if it does not already exist
-            if state.codes.contains_key(&Code(code.clone())) {
-                return Err(CanisterError::DuplicateKey(code.clone()));
-            } else {
+            if !state.codes.contains_key(&Code(code.clone())) {
                 state.pre_generated_codes.push(Code(code));
             }
         }

--- a/src/airdrop/src/lib.rs
+++ b/src/airdrop/src/lib.rs
@@ -143,8 +143,7 @@ fn add_codes(codes: Vec<String>) -> CustomResult<()> {
         for code in codes {
             // only add the code if it does not already exist
             if state.codes.contains_key(&Code(code.clone())) {
-                return Err(CanisterError::DuplicateKey(code.clone())
-                );
+                return Err(CanisterError::DuplicateKey(code.clone()));
             } else {
                 state.pre_generated_codes.push(Code(code));
             }
@@ -156,16 +155,9 @@ fn add_codes(codes: Vec<String>) -> CustomResult<()> {
 #[update(guard = "caller_is_admin")]
 fn add_admin(principal: Principal) -> CustomResult<()> {
     mutate_state(|state| {
-        // only add the admin if they do not already exist
-        if state.principals_admins.contains(&principal) {
-            return Err(CanisterError::DuplicateKey(
-                principal.to_string()
-            ));
-        } else {
-            state.principals_admins.insert(principal);
+        state.principals_admins.insert(principal);
 
-            Ok(())
-        }
+        Ok(())
     })
 }
 
@@ -175,9 +167,7 @@ fn add_manager(principal: Principal) -> CustomResult<()> {
     mutate_state(|state| {
         // only add the manager if they do not already exist
         if state.principals_managers.contains_key(&principal) {
-            return Err(CanisterError::DuplicateKey(
-                principal.to_string()
-            ));
+            return Err(CanisterError::DuplicateKey(principal.to_string()));
         } else {
             let principal_state = PrincipalState {
                 codes_generated: 0,

--- a/src/declarations/airdrop/airdrop.did.d.ts
+++ b/src/declarations/airdrop/airdrop.did.d.ts
@@ -13,6 +13,7 @@ export type CanisterError =
 	| { CodeAlreadyRedeemed: null }
 	| { TransactionUnkown: null }
 	| { CodeNotFound: null }
+	| { DuplicateKey: string }
 	| { NoCodeForII: null };
 export interface CodeInfo {
 	codes_generated: bigint;

--- a/src/declarations/airdrop/airdrop.factory.did.js
+++ b/src/declarations/airdrop/airdrop.factory.did.js
@@ -19,6 +19,7 @@ export const idlFactory = ({ IDL }) => {
 		CodeAlreadyRedeemed: IDL.Null,
 		TransactionUnkown: IDL.Null,
 		CodeNotFound: IDL.Null,
+		DuplicateKey: IDL.Text,
 		NoCodeForII: IDL.Null
 	});
 	const Result = IDL.Variant({ Ok: IDL.Null, Err: CanisterError });


### PR DESCRIPTION
We have three endpoints for adding resources to the canister state:
- admins
- managers
- code

We need to make sure none of them are added multiple times:
- admins - stored in a hashest - no issue 
- managers - we return an error as we add them one by one 
- code - silently failed as an early error return would mean we do not add the rest - otherwise we can create a list of codes that were not added and return them.