### PR TITLE
fix(frontend): workaround for AuthClient issue in Safari after logout

### DIFF
--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -1,23 +1,10 @@
-import { addressStore } from '$lib/stores/address.store';
-import { airdropStore } from '$lib/stores/airdrop.store';
 import { authStore, type AuthSignInParams } from '$lib/stores/auth.store';
-import { balancesStore } from '$lib/stores/balances.store';
 import { busy } from '$lib/stores/busy.store';
-import { erc20TokensStore } from '$lib/stores/erc20.store';
-import { metamaskStore } from '$lib/stores/metamask.store';
 import { toastsClean, toastsError, toastsShow } from '$lib/stores/toasts.store';
-import { transactionsStore } from '$lib/stores/transactions.store';
-
-const resetStores = () => {
-	addressStore.reset();
-	balancesStore.reset();
-	transactionsStore.reset();
-	erc20TokensStore.reset();
-	metamaskStore.reset();
-	airdropStore.reset;
-
-	busy.stop();
-};
+import type { ToastMsg } from '$lib/types/toast';
+import { replaceHistory } from '$lib/utils/route.utils';
+import type { ToastLevel } from '@dfinity/gix-components';
+import { isNullish } from '@dfinity/utils';
 
 export const signIn = async (
 	params: AuthSignInParams
@@ -48,17 +35,77 @@ export const signIn = async (
 	}
 };
 
-export const signOut = async () => {
+export const signOut = (): Promise<void> => logout({});
+
+export const idleSignOut = async () =>
+	logout({
+		msg: {
+			text: 'You have been logged out because your session has expired.',
+			level: 'warn'
+		}
+	});
+
+const logout = async ({ msg = undefined }: { msg?: ToastMsg }) => {
+	// To mask not operational UI (a side effect of sometimes slow JS loading after window.reload because of service worker and no cache).
+	busy.start();
+
 	await authStore.signOut();
 
-	resetStores();
+	if (msg) {
+		appendMsgToUrl(msg);
+	}
+
+	// Auth: Delegation and identity are cleared from indexedDB by agent-js so, we do not need to clear these
+
+	// Preferences: We do not clear local storage as well. It contains anonymous information such as the selected theme.
+	// Information the user want to preserve across sign-in. e.g. if I select the light theme, logout and sign-in again, I am happy if the dapp still uses the light theme.
+
+	// We reload the page to make sure all the states are cleared
+	window.location.reload();
 };
 
-export const idleSignOut = async () => {
-	await signOut();
+const PARAM_MSG = 'msg';
+const PARAM_LEVEL = 'level';
 
-	toastsShow({
-		text: 'You have been logged out because your session has expired.',
-		level: 'warn'
-	});
+/**
+ * If a message was provided to the logout process - e.g. a message informing the logout happened because the session timed-out - append the information to the url as query params
+ */
+const appendMsgToUrl = (msg: ToastMsg) => {
+	const { text, level } = msg;
+
+	const url: URL = new URL(window.location.href);
+
+	url.searchParams.append(PARAM_MSG, encodeURI(text));
+	url.searchParams.append(PARAM_LEVEL, level);
+
+	replaceHistory(url);
+};
+
+/**
+ * If the url contains a msg that has been provided on logout, display it as a toast message. Cleanup url afterwards - we don't want the user to see the message again if reloads the browser
+ */
+export const displayAndCleanLogoutMsg = () => {
+	const urlParams: URLSearchParams = new URLSearchParams(window.location.search);
+
+	const msg: string | null = urlParams.get(PARAM_MSG);
+
+	if (isNullish(msg)) {
+		return;
+	}
+
+	// For simplicity reason we assume the level pass as query params is one of the type ToastLevel
+	const level: ToastLevel = (urlParams.get(PARAM_LEVEL) as ToastLevel | null) ?? 'success';
+
+	toastsShow({ text: msg, level });
+
+	cleanUpMsgUrl();
+};
+
+const cleanUpMsgUrl = () => {
+	const url: URL = new URL(window.location.href);
+
+	url.searchParams.delete(PARAM_MSG);
+	url.searchParams.delete(PARAM_LEVEL);
+
+	replaceHistory(url);
 };

--- a/src/frontend/src/lib/services/auth.services.ts
+++ b/src/frontend/src/lib/services/auth.services.ts
@@ -96,7 +96,7 @@ export const displayAndCleanLogoutMsg = () => {
 	// For simplicity reason we assume the level pass as query params is one of the type ToastLevel
 	const level: ToastLevel = (urlParams.get(PARAM_LEVEL) as ToastLevel | null) ?? 'success';
 
-	toastsShow({ text: msg, level });
+	toastsShow({ text: decodeURI(msg), level });
 
 	cleanUpMsgUrl();
 };

--- a/src/frontend/src/lib/utils/route.utils.ts
+++ b/src/frontend/src/lib/utils/route.utils.ts
@@ -1,0 +1,20 @@
+/**
+ * Update browser URL. To be use only for really particular use case that do not include navigation and loading data.
+ */
+export const replaceHistory = (url: URL) => {
+	if (!supportsHistory()) {
+		window.location.replace(url);
+		return;
+	}
+
+	history.replaceState({}, '', url);
+};
+
+/**
+ * Test if the History API is supported by the devices. On old phones it might not be the case.
+ * Source: https://stackoverflow.com/a/6825002/5404186
+ */
+const supportsHistory = (): boolean =>
+	window.history !== undefined &&
+	'pushState' in window.history &&
+	typeof window.history.pushState !== 'undefined';

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -11,6 +11,8 @@
 	import { authSignedInStore } from '$lib/derived/auth.derived';
 	import SignIn from '$lib/components/pages/SignIn.svelte';
 	import Banner from '$lib/components/core/Banner.svelte';
+	import { displayAndCleanLogoutMsg } from '$lib/services/auth.services';
+	import { toastsError } from '$lib/stores/toasts.store';
 
 	/**
 	 * Init authentication
@@ -26,8 +28,13 @@
 		try {
 			await authStore.sync();
 		} catch (err: unknown) {
-			console.error(err);
+			toastsError({
+				msg: { text: 'Unexpected issue while syncing the status of your authentication.' },
+				err: JSON.stringify(Err)
+			});
 		}
+
+		displayAndCleanLogoutMsg();
 	};
 
 	/**

--- a/src/frontend/src/routes/+layout.svelte
+++ b/src/frontend/src/routes/+layout.svelte
@@ -30,7 +30,7 @@
 		} catch (err: unknown) {
 			toastsError({
 				msg: { text: 'Unexpected issue while syncing the status of your authentication.' },
-				err: JSON.stringify(Err)
+				err
 			});
 		}
 


### PR DESCRIPTION
> We encountered an issue while testing the Oisy Wallet of the foundation with the `@dfinity/auth-client library`. In Safari, following a logout, the subsequent login using the library gets blocked by the browser, which prevents the opening of a new window or popup. The only feasible workaround is to force a window.location.reload() after signing out.

<img width="1536" alt="Capture d’écran 2023-09-24 à 13 18 23" src="https://github.com/dfinity/ic-eth-wallet/assets/16886711/52cea986-4c73-4278-aa43-f933cd05e6c4">
<img width="1536" alt="Capture d’écran 2023-09-24 à 13 18 17" src="https://github.com/dfinity/ic-eth-wallet/assets/16886711/458ba348-9467-4b6f-82ce-42a6ca0cf1e4">
<img width="1536" alt="Capture d’écran 2023-09-24 à 13 18 12" src="https://github.com/dfinity/ic-eth-wallet/assets/16886711/2dfd9b34-cfce-446b-a213-b9ab62610832">
